### PR TITLE
refactor!: ESM-only

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
 github: [fb55]
-tidelift: "npm/boolbase"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish
+on:
+    push:
+        tags:
+            - "v*"
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+
+        permissions:
+            contents: read
+            id-token: write
+
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+              with:
+                  node-version: lts/*
+                  registry-url: https://registry.npmjs.org
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Create jsr.json based on package.json
+              run: |
+                  node --input-type=module -e '
+                    import { readFileSync, writeFileSync } from "fs";
+                    const p = JSON.parse(readFileSync("./package.json", "utf8"));
+                    const jsrJson = {
+                        name: `@cheerio/${p.name}`,
+                        version: p.version,
+                        exports: { ".": "./src/index.ts" },
+                    };
+                    writeFileSync("./jsr.json", JSON.stringify(jsrJson, null, 2));
+                  '
+
+            - name: Publish package to JSR
+              run: npx jsr publish
+
+            - name: Publish package to npm
+              run: npm publish --provenance --access public

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/index.js
+++ b/index.js
@@ -1,8 +1,0 @@
-module.exports = {
-	trueFunc: function trueFunc(){
-		return true;
-	},
-	falseFunc: function falseFunc(){
-		return false;
-	}
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "boolbase",
+  "version": "2.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "boolbase",
+      "version": "2.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,23 @@
 {
   "name": "boolbase",
-  "version": "1.0.0",
+  "version": "2.0.0",
+  "type": "module",
   "description": "two functions: One that returns true, one that returns false",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "test": "node tests.js"
+    "build": "tsc",
+    "test": "npm run build && node --test",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",
@@ -19,5 +32,14 @@
   "bugs": {
     "url": "https://github.com/fb55/boolbase/issues"
   },
-  "homepage": "https://github.com/fb55/boolbase"
+  "homepage": "https://github.com/fb55/boolbase",
+  "engines": {
+    "node": ">=20.19.0"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/fb55"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,7 @@
+export function trueFunc(): true {
+	return true;
+}
+
+export function falseFunc(): false {
+	return false;
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,13 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { trueFunc, falseFunc } from "../dist/index.js";
+
+describe("boolbase", () => {
+	it("trueFunc should return true", () => {
+		assert.strictEqual(trueFunc(), true);
+	});
+
+	it("falseFunc should return false", () => {
+		assert.strictEqual(falseFunc(), false);
+	});
+});

--- a/tests.js
+++ b/tests.js
@@ -1,5 +1,0 @@
-var assert = require("assert"),
-    boolbase = require("./");
-
-assert.strictEqual(boolbase.trueFunc(), true, "should evaluate to true");
-assert.strictEqual(boolbase.falseFunc(), false, "should evaluate to false");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "target": "es2022",
+        "module": "nodenext",
+        "moduleResolution": "nodenext",
+        "declaration": true,
+        "declarationMap": true,
+        "outDir": "dist",
+        "rootDir": "src",
+        "strict": true,
+        "isolatedDeclarations": true,
+        "isolatedModules": true
+    },
+    "include": ["src"]
+}


### PR DESCRIPTION
- Convert to TypeScript
- Set type: module, add exports field
- Add node:test tests
- Add engines >= 20.19.0
- Add publish workflow (npm + JSR)
- Remove Tidelift from FUNDING.yml
- Bump to v2.0.0

BREAKING CHANGE: This package is now ESM-only.